### PR TITLE
Adding status tips and tool tips where non existant

### DIFF
--- a/src-qt5/gui_client/pages/page_firewall.ui
+++ b/src-qt5/gui_client/pages/page_firewall.ui
@@ -111,6 +111,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="tool_enable">
+       <property name="toolTip">
+        <string>Enabled at boot</string>
+       </property>
        <property name="statusTip">
         <string>Automatically start the firewall on boot</string>
        </property>
@@ -131,6 +134,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="tool_disable">
+       <property name="toolTip">
+        <string>Disbaled at boot</string>
+       </property>
        <property name="statusTip">
         <string>Do not start the firewall on boot</string>
        </property>
@@ -289,6 +295,9 @@
           </item>
           <item>
            <widget class="QToolButton" name="tool_open_port">
+            <property name="toolTip">
+             <string>Open Port</string>
+            </property>
             <property name="statusTip">
              <string>Open the designated port</string>
             </property>

--- a/src-qt5/gui_client/pages/page_lp.ui
+++ b/src-qt5/gui_client/pages/page_lp.ui
@@ -234,6 +234,9 @@
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QToolButton" name="tool_rep_add">
+           <property name="toolTip">
+            <string>New</string>
+           </property>
            <property name="statusTip">
             <string>Create a new replication</string>
            </property>
@@ -248,6 +251,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="tool_rep_remove">
+           <property name="toolTip">
+            <string>Remove</string>
+           </property>
            <property name="statusTip">
             <string>Remove a replication</string>
            </property>
@@ -262,6 +268,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="tool_rep_modify">
+           <property name="toolTip">
+            <string>Modify</string>
+           </property>
            <property name="statusTip">
             <string>Modify selected replication</string>
            </property>
@@ -573,6 +582,9 @@
             </property>
             <item>
              <widget class="QToolButton" name="tool_schedule_addsnap">
+              <property name="toolTip">
+               <string>Add snapshot to schedule</string>
+              </property>
               <property name="statusTip">
                <string>Add snapshot to schedule</string>
               </property>
@@ -587,6 +599,9 @@
             </item>
             <item>
              <widget class="QToolButton" name="tool_schedule_modifysnap">
+              <property name="toolTip">
+               <string>Modify the selected snapshot schedule</string>
+              </property>
               <property name="statusTip">
                <string>Modify the selected snapshot schedule</string>
               </property>
@@ -601,6 +616,9 @@
             </item>
             <item>
              <widget class="QToolButton" name="tool_schedule_rmsnap">
+              <property name="toolTip">
+               <string>Remove snapshot from schedule</string>
+              </property>
               <property name="statusTip">
                <string>Remove snapshot from schedule</string>
               </property>
@@ -655,6 +673,9 @@
             </property>
             <item>
              <widget class="QToolButton" name="tool_schedule_addscrub">
+              <property name="toolTip">
+               <string>Add ZFS scrub to schedule</string>
+              </property>
               <property name="statusTip">
                <string>Add ZFS scrub to schedule</string>
               </property>
@@ -669,6 +690,9 @@
             </item>
             <item>
              <widget class="QToolButton" name="tool_schedule_modifyscrub">
+              <property name="toolTip">
+               <string>Modify the selected scrub schedule</string>
+              </property>
               <property name="statusTip">
                <string>Modify the selected scrub schedule</string>
               </property>
@@ -683,6 +707,9 @@
             </item>
             <item>
              <widget class="QToolButton" name="tool_schedule_rmscrub">
+              <property name="toolTip">
+               <string>Remove scheduled scrub</string>
+              </property>
               <property name="statusTip">
                <string>Remove scheduled scrub</string>
               </property>

--- a/src-qt5/gui_client/pages/page_pkg.ui
+++ b/src-qt5/gui_client/pages/page_pkg.ui
@@ -32,7 +32,7 @@
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_repo">
       <attribute name="icon">
@@ -138,6 +138,12 @@
           </item>
           <item>
            <widget class="QToolButton" name="tool_repo_search">
+            <property name="toolTip">
+             <string>Search</string>
+            </property>
+            <property name="statusTip">
+             <string>Search</string>
+            </property>
             <property name="text">
              <string>...</string>
             </property>
@@ -229,8 +235,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>449</width>
-                <height>232</height>
+                <width>98</width>
+                <height>28</height>
                </rect>
               </property>
              </widget>
@@ -305,8 +311,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>449</width>
-                <height>236</height>
+                <width>98</width>
+                <height>28</height>
                </rect>
               </property>
              </widget>
@@ -409,8 +415,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>449</width>
-                <height>232</height>
+                <width>98</width>
+                <height>28</height>
                </rect>
               </property>
              </widget>
@@ -872,8 +878,8 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>98</width>
-                    <height>35</height>
+                    <width>405</width>
+                    <height>138</height>
                    </rect>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -1056,6 +1062,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="tool_local_clean">
+           <property name="toolTip">
+            <string>Remove orphaned packages</string>
+           </property>
            <property name="statusTip">
             <string>Automatically remove any orphaned packages</string>
            </property>
@@ -1112,6 +1121,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="tool_local_filter">
+           <property name="toolTip">
+            <string>View Options</string>
+           </property>
            <property name="statusTip">
             <string>Adjust View Options</string>
            </property>

--- a/src-qt5/gui_client/pages/page_services.ui
+++ b/src-qt5/gui_client/pages/page_services.ui
@@ -18,6 +18,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QToolButton" name="tool_start">
+       <property name="toolTip">
+        <string>Start</string>
+       </property>
        <property name="statusTip">
         <string>Start the selected service</string>
        </property>
@@ -32,6 +35,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="tool_stop">
+       <property name="toolTip">
+        <string>Stop</string>
+       </property>
        <property name="statusTip">
         <string>Stop the selected service</string>
        </property>
@@ -46,6 +52,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="tool_restart">
+       <property name="toolTip">
+        <string>Restart</string>
+       </property>
        <property name="statusTip">
         <string>Restart the selected service</string>
        </property>
@@ -73,6 +82,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="tool_enable">
+       <property name="toolTip">
+        <string>Enabled</string>
+       </property>
        <property name="statusTip">
         <string>Enable automatic start on boot</string>
        </property>
@@ -87,6 +99,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="tool_disable">
+       <property name="toolTip">
+        <string>Disabled</string>
+       </property>
        <property name="statusTip">
         <string>Disable automatic start on boot</string>
        </property>

--- a/src-qt5/gui_client/pages/page_updates.ui
+++ b/src-qt5/gui_client/pages/page_updates.ui
@@ -20,7 +20,7 @@
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="icon">

--- a/src-qt5/gui_client/pages/page_users.ui
+++ b/src-qt5/gui_client/pages/page_users.ui
@@ -125,8 +125,8 @@
              <widget class="QWidget" name="scrollAreaWidgetContents">
               <property name="geometry">
                <rect>
-                <x>0</x>
-                <y>0</y>
+                <x>-30</x>
+                <y>-61</y>
                 <width>235</width>
                 <height>277</height>
                </rect>
@@ -204,6 +204,12 @@
                   <widget class="QToolButton" name="tool_user_showpassword">
                    <property name="focusPolicy">
                     <enum>Qt::ClickFocus</enum>
+                   </property>
+                   <property name="toolTip">
+                    <string>View</string>
+                   </property>
+                   <property name="statusTip">
+                    <string>View password</string>
                    </property>
                    <property name="text">
                     <string notr="true"/>
@@ -352,7 +358,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>182</width>
+                <width>203</width>
                 <height>260</height>
                </rect>
               </property>
@@ -527,6 +533,12 @@
                     </item>
                     <item>
                      <widget class="QToolButton" name="tool_pc_findkey">
+                      <property name="toolTip">
+                       <string>Select File</string>
+                      </property>
+                      <property name="statusTip">
+                       <string>Select Key File</string>
+                      </property>
                       <property name="text">
                        <string>...</string>
                       </property>
@@ -905,6 +917,12 @@
             </item>
             <item>
              <widget class="QPushButton" name="push_group_adduser">
+              <property name="toolTip">
+               <string>Add</string>
+              </property>
+              <property name="statusTip">
+               <string>Add user to selected group</string>
+              </property>
               <property name="text">
                <string notr="true"/>
               </property>
@@ -953,6 +971,12 @@
             </item>
             <item>
              <widget class="QPushButton" name="push_group_rmuser">
+              <property name="toolTip">
+               <string>Remove</string>
+              </property>
+              <property name="statusTip">
+               <string>Remove user from selected group</string>
+              </property>
               <property name="text">
                <string notr="true"/>
               </property>


### PR DESCRIPTION
This is cosmetic.  It was pointed out by a community member that some buttons had status tips but no tool tips and also that some pages have neither for some graphical buttons while other buttons did.