### PR TITLE
Add support for -help as a command line argument to the gui client

### DIFF
--- a/src-qt5/gui_client/main.cpp
+++ b/src-qt5/gui_client/main.cpp
@@ -24,6 +24,14 @@ QSslConfiguration SSL_cfg, SSL_cfg_bridge; //null-loaded config objects
 
 int main( int argc, char ** argv )
 {
+    // see if the user wants the args
+    if (argc == 2 && QString(argv[1]) == "-help")
+    {
+        qDebug() << "Usage: " << QString(argv[0]) << " [-localhost] [-page N]";
+        qDebug() << "    -page N start on page N";
+        qDebug() << "    -localhost connect to server on localhost";
+        return 0;
+    }
   //Load the application
   QApplication A(argc, argv);
 


### PR DESCRIPTION
Running sysadm-client in a window manager without support for a systray, the command appears to hang for about 5 minutes before exiting with a message about not finding systray.
Trying to run sysadm-client [-help | --help | -h] gave the same results.
Tried man sysadm-client, didn't find a man page
Looking at the source code discovered that -page N and -localhost are the only 2 valid arguments.
This change simply adds a -help argument that prints out simple Usage and exits. 