### PR TITLE
Fix Typo in Firewall Manager: disbaled -> disabled

### DIFF
--- a/src-qt5/gui_client/pages/page_firewall.ui
+++ b/src-qt5/gui_client/pages/page_firewall.ui
@@ -135,7 +135,7 @@
      <item>
       <widget class="QToolButton" name="tool_disable">
        <property name="toolTip">
-        <string>Disbaled at boot</string>
+        <string>Disabled at boot</string>
        </property>
        <property name="statusTip">
         <string>Do not start the firewall on boot</string>


### PR DESCRIPTION
Noticed a small typo in the Firewall Manager. Tooltip on the disable-at-boot button should say "disabled" and not "disbaled".