### PR TITLE
s/IBUS/Fcitx/: Replace for fit with current TrueOS.

### DIFF
--- a/src-qt5/gui_client/i18n/SysAdm_af.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_af.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ar.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ar.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_az.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_az.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_bg.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_bg.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_bn.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_bn.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_bs.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_bs.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ca.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ca.ts
@@ -1700,8 +1700,8 @@ Ubicació del fitxer: %1</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
-        <translation>Força l'entrada de teclat IBUS</translation>
+        <source>Force Fcitx keyboard input</source>
+        <translation>Força l'entrada de teclat Fcitx</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="643"/>

--- a/src-qt5/gui_client/i18n/SysAdm_cs.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_cs.ts
@@ -1700,8 +1700,8 @@ Umístění souboru: %1</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
-        <translation>Vynutit IBUS klávesnicový vstup</translation>
+        <source>Force Fcitx keyboard input</source>
+        <translation>Vynutit Fcitx klávesnicový vstup</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="643"/>

--- a/src-qt5/gui_client/i18n/SysAdm_cy.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_cy.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_da.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_da.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_de.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_de.ts
@@ -1700,8 +1700,8 @@ Dateiort: %1</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
-        <translation>IBUS-Tastatureingabe erzwingen</translation>
+        <source>Force Fcitx keyboard input</source>
+        <translation>Fcitx-Tastatureingabe erzwingen</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="643"/>

--- a/src-qt5/gui_client/i18n/SysAdm_el.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_el.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_en.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_en.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_en_AU.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_en_AU.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_en_GB.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_en_GB.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_en_US.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_en_US.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_en_ZA.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_en_ZA.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_es.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_es.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"></location>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_et.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_et.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_eu.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_eu.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_fa.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_fa.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_fi.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_fi.ts
@@ -1700,7 +1700,7 @@ Tiedoston sijainti: %1</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_fr.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_fr.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_fr_CA.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_fr_CA.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_fur.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_fur.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_gl.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_gl.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_he.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_he.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_hi.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_hi.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_hr.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_hr.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_hu.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_hu.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_id.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_id.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_is.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_is.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_it.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_it.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"></location>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ja.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ja.ts
@@ -1700,7 +1700,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ka.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ka.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ko.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ko.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_lt.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_lt.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_lv.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_lv.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_mk.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_mk.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_mn.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_mn.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ms.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ms.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_mt.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_mt.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_nb.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_nb.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ne.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ne.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_nl.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_nl.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_pa.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_pa.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_pl.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_pl.ts
@@ -1700,7 +1700,7 @@ Lokalizacja pliku: %1</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_pt.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_pt.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_pt_BR.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_pt_BR.ts
@@ -1700,8 +1700,8 @@ Localização do Arquivo: %1</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
-        <translation>Forçar entrada de teclado IBUS</translation>
+        <source>Force Fcitx keyboard input</source>
+        <translation>Forçar entrada de teclado Fcitx</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="643"/>

--- a/src-qt5/gui_client/i18n/SysAdm_ro.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ro.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ru.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ru.ts
@@ -1699,8 +1699,8 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"></location>
-        <source>Force IBUS keyboard input</source>
-        <translation>Принудительный ввод IBUS клавиатуры</translation>
+        <source>Force Fcitx keyboard input</source>
+        <translation>Принудительный ввод Fcitx клавиатуры</translation>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="643"></location>

--- a/src-qt5/gui_client/i18n/SysAdm_sa.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_sa.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_sk.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_sk.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_sl.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_sl.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_sr.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_sr.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_sv.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_sv.ts
@@ -1694,7 +1694,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"></location>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_sw.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_sw.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ta.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ta.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_tg.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_tg.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_th.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_th.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_tr.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_tr.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_uk.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_uk.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_ur.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_ur.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_uz.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_uz.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_vi.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_vi.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_zh_CN.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_zh_CN.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_zh_HK.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_zh_HK.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_zh_TW.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_zh_TW.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/i18n/SysAdm_zu.ts
+++ b/src-qt5/gui_client/i18n/SysAdm_zu.ts
@@ -1693,7 +1693,7 @@ File Location: %1</source>
     </message>
     <message>
         <location filename="../pages/page_system.ui" line="607"/>
-        <source>Force IBUS keyboard input</source>
+        <source>Force Fcitx keyboard input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src-qt5/gui_client/pages/page_system.ui
+++ b/src-qt5/gui_client/pages/page_system.ui
@@ -622,7 +622,7 @@
         <item row="0" column="0">
          <widget class="QCheckBox" name="checkForceIbus_3">
           <property name="text">
-           <string>Force IBUS keyboard input</string>
+           <string>Force Fcitx keyboard input</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
In now, TrueOS using Fcitx<https://fcitx-im.org/>.
But, "IBUS" remain in SysAdm UI string.

I suggest replace "IBUS" with "Fcitx" or some words(But need another translations).
(ex: "Multilingual input method")